### PR TITLE
Fixes the armor level freeze when logout

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build src/Perpetuum.ServerService2/Perpetuum.ServerService2.csproj --no-restore --configuration Release --verbosity quiet
+      run: dotnet build src/Perpetuum.ServerService2/Perpetuum.ServerService2.csproj --no-restore --configuration Release --verbosity quiet -p:Platform=x64
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v4
       with:
         name: Perpetuum-Server-v2-${{ github.sha }}
-        path: ${{ env.Workspace }}/bin/Release/net8.0
+        path: ${{ env.Workspace }}/bin/x64/Release/net8.0
       if: ${{ github.event_name == 'push'}}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ![opp-server2](opp-server2.png)
 
+[![Build Perpetuum.Server Service v2](https://github.com/OpenPerpetuum/PerpetuumServer2/actions/workflows/dotnet.yml/badge.svg?branch=develop)](https://github.com/OpenPerpetuum/PerpetuumServer2/actions/workflows/dotnet.yml)
+
 # The Open Perpetuum Server 2
 

--- a/src/Perpetuum/Zones/Terrains/IntervalLayerSaver.cs
+++ b/src/Perpetuum/Zones/Terrains/IntervalLayerSaver.cs
@@ -29,13 +29,17 @@ namespace Perpetuum.Zones.Terrains
 
         public override void Stop()
         {
-            SaveLayer();
+            // When stopping the server, we save only the modified layers.
+            if (Interlocked.CompareExchange(ref _dirty, 0, 1) == 1)
+            {
+                SaveLayer();
+            }
             base.Stop();
         }
 
         public override void Update(TimeSpan time)
         {
-            if ( Interlocked.CompareExchange(ref _dirty,0,1) == 0)
+            if (Interlocked.CompareExchange(ref _dirty, 0, 1) == 0)
                 return;
 
             SaveLayer();

--- a/src/Perpetuum/Zones/ZoneSession.cs
+++ b/src/Perpetuum/Zones/ZoneSession.cs
@@ -949,6 +949,7 @@ namespace Perpetuum.Zones
 
             using (TransactionScope scope = Db.CreateTransaction())
             {
+                _player.DynamicProperties.Update(k.armor, _player.Armor.Ratio(_player.ArmorMax));
                 _player.Save();
                 character.ZoneId = _zone.Id;
                 character.ZonePosition = _player.CurrentPosition;


### PR DESCRIPTION
Corrections have been made for:
- under certain conditions, the armor level is not remembered when exiting the game.

The patch also contains:
- Updated README.md;
- Action creates an assembly for the x64 platform;
- When stopping the server, we save only the modified layers.
