### PR TITLE
Add ISSUE-033..035 to backlog from local setup validation

### DIFF
--- a/docs/backlog/issues.md
+++ b/docs/backlog/issues.md
@@ -36,19 +36,20 @@ Priority: MEDIUM
 Area: Documentation
 
 ### Problem
-Two sets of references in `CLAUDE.md` do not match the repository:
+Three sets of references in `CLAUDE.md` do not match the repository:
 
 1. Build & Run documents `dotnet run -- --GameRoot "<path>"`. `src/Perpetuum.Server/Program.cs` declares the game root as a positional argument via `app.Argument("<GAMEROOT>", ...)`, so the option does not exist and the run fails with `Unrecognized option '--GameRoot'`. The working form is `dotnet run -- "<path>"`.
-2. Authoritative Documentation links `docs/CONCERNS.md`, `docs/CONVENTIONS.md`, `docs/INTEGRATIONS.md`, `docs/STACK.md`, `docs/STRUCTURE.md` and `docs/TESTING.md`. None of those paths exist; all six files live under `docs/codebase/`. Only the `ARCHITECTURE.md` entry already points at `docs/codebase/`.
+2. Eight `docs/` references point at files that do not exist. Authoritative Documentation links `docs/CONCERNS.md` (line 77), `docs/CONVENTIONS.md` (80), `docs/INTEGRATIONS.md` (83), `docs/STACK.md` (86), `docs/STRUCTURE.md` (89) and `docs/TESTING.md` (92); Technical Debt Rules links `docs/CONCERNS.md` again (222) and Code Placement links `docs/STRUCTURE.md` again (316). All six files live under `docs/codebase/`. Only the `ARCHITECTURE.md` entry (74) already points there.
+3. `.claude/knowledge/architecture.md` does not exist and is referenced twice: as the file to update when introducing major architectural changes (line 44), and as the architecture deep-dive in the Where to Edit table (331). `.claude/knowledge/` contains only `codebase-graph.md`.
 
 ### Impact
-`CLAUDE.md` is the instruction file for agent-assisted work, so a wrong path or command is followed rather than questioned. The documented run command cannot succeed, and six of seven documentation pointers resolve to nothing.
+`CLAUDE.md` is the instruction file for agent-assisted work, so a wrong path or command is followed rather than questioned. The documented run command cannot succeed, and ten path references resolve to nothing — eight under `docs/` and two under `.claude/knowledge/`.
 
 ### Proposed Fix
-Correct the run command to the positional form and prefix the six documentation paths with `docs/codebase/`.
+Correct the run command to the positional form and prefix the eight `docs/` paths with `codebase/`. The two `.claude/knowledge/architecture.md` references need a maintainer decision: repoint them at `docs/codebase/ARCHITECTURE.md`, which already holds the architecture documentation, or create the missing file.
 
 ### Notes
-`--GameRoot` remains valid for `Perpetuum.ServerService2`, which reads `GameRoot` from `appsettings.json`; only the `Perpetuum.Server` console entry point takes it positionally.
+`--GameRoot` remains valid for `Perpetuum.ServerService2`, which reads `GameRoot` from `appsettings.json`; only the `Perpetuum.Server` console entry point takes it positionally. Line numbers are against `CLAUDE.md` at `b8d2ec2` (P36.7). `Commands.cs` and `completed.md` also appear in the file, but as bare filenames in prose rather than paths.
 
 ## ISSUE-033 - FreeRoamingPathFinder throws on presences with no flocks
 

--- a/docs/backlog/issues.md
+++ b/docs/backlog/issues.md
@@ -1,6 +1,72 @@
 # Last ID used
 
-032
+035
+
+## ISSUE-035 - Server fails to start with the perpetuum.ini produced by the official installer
+
+Status: TODO
+Priority: HIGH
+Area: Configuration / Setup
+
+### Problem
+The `perpetuum.ini` written by the Perpetuum Dedicated Server installer carries a connection string that `Microsoft.Data.SqlClient` rejects, in two independent ways:
+
+1. `Connection Reset=True` — the keyword was removed in `Microsoft.Data.SqlClient`. Startup aborts with an unsupported-keyword error naming `Connection Reset`.
+2. No `TrustServerCertificate` or `Encrypt` setting — `Microsoft.Data.SqlClient` 4.0+ defaults `Encrypt` to `true`, so a local SQL Server using a self-signed certificate fails logon in the SSL provider, reporting that the certificate chain was issued by an untrusted authority.
+
+Both abort during `PerpetuumBootstrapper.Init`, before any zone is loaded. The legacy `System.Data.SqlClient` used by the original server accepted the first keyword and defaulted `Encrypt` to `false`, so the shipped file worked there.
+
+### Impact
+Every fresh local setup fails on first launch. Neither error message names `perpetuum.ini`, so the cause is not obvious from the output. No file under `docs/` mentions either change.
+
+### Proposed Fix
+Document the required connection-string edits in a setup page under `docs/codebase/`. Optionally, ignore unsupported legacy keywords when deserializing `GlobalConfiguration` and raise an error that names `perpetuum.ini` and the offending key.
+
+### Notes
+Reproduced against SQL Server 2022 Express, named instance, Windows integrated auth. Both errors were observed on a pt-BR install and are quoted here in translation, so search by condition rather than by exact string. Working connection string after both edits:
+
+`Server=localhost\PERPSQL;Database=perpetuumsa;Trusted_Connection=True;TrustServerCertificate=True;Pooling=True;Connection Timeout=30;Connection Lifetime=260;Min Pool Size=20;Max Pool Size=60;`
+
+`TrustServerCertificate=True` disables server certificate validation. It is appropriate for a local development instance only and must not be carried into a deployment where the connection leaves the machine.
+
+## ISSUE-034 - CLAUDE.md contains stale references that misdirect contributors
+
+Status: TODO
+Priority: MEDIUM
+Area: Documentation
+
+### Problem
+Two sets of references in `CLAUDE.md` do not match the repository:
+
+1. Build & Run documents `dotnet run -- --GameRoot "<path>"`. `src/Perpetuum.Server/Program.cs` declares the game root as a positional argument via `app.Argument("<GAMEROOT>", ...)`, so the option does not exist and the run fails with `Unrecognized option '--GameRoot'`. The working form is `dotnet run -- "<path>"`.
+2. Authoritative Documentation links `docs/CONCERNS.md`, `docs/CONVENTIONS.md`, `docs/INTEGRATIONS.md`, `docs/STACK.md`, `docs/STRUCTURE.md` and `docs/TESTING.md`. None of those paths exist; all six files live under `docs/codebase/`. Only the `ARCHITECTURE.md` entry already points at `docs/codebase/`.
+
+### Impact
+`CLAUDE.md` is the instruction file for agent-assisted work, so a wrong path or command is followed rather than questioned. The documented run command cannot succeed, and six of seven documentation pointers resolve to nothing.
+
+### Proposed Fix
+Correct the run command to the positional form and prefix the six documentation paths with `docs/codebase/`.
+
+### Notes
+`--GameRoot` remains valid for `Perpetuum.ServerService2`, which reads `GameRoot` from `appsettings.json`; only the `Perpetuum.Server` console entry point takes it positionally.
+
+## ISSUE-033 - FreeRoamingPathFinder throws on presences with no flocks
+
+Status: TODO
+Priority: LOW
+Area: NPC AI / Logging
+
+### Problem
+`FreeRoamingPathFinder.TryGetMaxHomeRange` calls `presence.Flocks.Max(f => f.HomeRange)` and `TryGetMinSlope` calls `presence.Flocks.GetMembers().Min(m => m.Slope)`. When the sequence is empty, LINQ raises `InvalidOperationException: Sequence contains no elements`. The surrounding `try/catch` swallows it, writes a full stack trace through `Logger.Exception`, and returns the fallback value.
+
+### Impact
+A presence with no flocks is a normal state, not a fault, so each one emits a stack trace during zone startup. Exception handling is used as ordinary control flow on a per-presence path, and the resulting traces make genuine faults harder to spot in the log.
+
+### Proposed Fix
+Project the value and use `DefaultIfEmpty` so the empty case yields the fallback without throwing, keeping the `try/catch` for genuinely unexpected failures.
+
+### Notes
+Observed during startup against a P36 database. Existing behaviour must be preserved: empty flocks yield `10` after `Clamp(10, 40)`, and empty members yield `ZoneExtensions.MIN_SLOPE`.
 
 ## ISSUE-032 - Recurring season creates duplicate next-run on each cache refresh before new run starts
 


### PR DESCRIPTION
## What

Adds three entries to `docs/backlog/issues.md` and bumps `# Last ID used` from `032` to `035`. No code changes — backlog records only.

## Why

Found while building and running a local P36 server from a clean checkout of `develop`. Each is reproducible, and none is currently recorded in the backlog.

| ID | Priority | Summary |
|---|---|---|
| ISSUE-035 | HIGH | The `perpetuum.ini` produced by the official Dedicated Server installer will not start server2. `Connection Reset` was removed from `Microsoft.Data.SqlClient`, and `Encrypt` now defaults to `true`, so a local SQL Server with a self-signed certificate also fails logon. Both abort inside `PerpetuumBootstrapper.Init`, and neither message names the config file. |
| ISSUE-034 | MEDIUM | `CLAUDE.md` documents `dotnet run -- --GameRoot "<path>"`, but `src/Perpetuum.Server/Program.cs` declares the game root as a positional argument, so the option is rejected. Separately, six of the seven Authoritative Documentation paths point at `docs/` while those files live under `docs/codebase/`. |
| ISSUE-033 | LOW | `FreeRoamingPathFinder.TryGetMaxHomeRange` and `TryGetMinSlope` call `Max`/`Min` on sequences that can be empty. An empty sequence is a normal state, but it throws, is caught, and writes a stack trace to the log for each affected presence. |

## Notes

Entries follow the format documented in `CLAUDE.md` (`Status`/`Priority`/`Area`, then Problem/Impact/Proposed Fix/Notes) and are inserted in descending ID order.

Happy to follow up with fixes as separate PRs — ISSUE-034 and ISSUE-033 are both small and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
