### PR TITLE
Stop FreeRoamingPathFinder from throwing on empty flocks

### DIFF
--- a/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/FreeRoamingPathFinder.cs
+++ b/src/Perpetuum/Zones/NpcSystem/Presences/PathFinders/FreeRoamingPathFinder.cs
@@ -27,7 +27,11 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
         {
             try
             {
-                return presence.Flocks.Max(f => f.HomeRange).Clamp(10, 40);
+                return presence.Flocks
+                    .Select(f => f.HomeRange)
+                    .DefaultIfEmpty(10)
+                    .Max()
+                    .Clamp(10, 40);
             }
             catch(Exception e)
             {
@@ -40,7 +44,10 @@ namespace Perpetuum.Zones.NpcSystem.Presences.PathFinders
         {
             try
             {
-                return presence.Flocks.GetMembers().Min(m => m.Slope);
+                return presence.Flocks.GetMembers()
+                    .Select(m => m.Slope)
+                    .DefaultIfEmpty(ZoneExtensions.MIN_SLOPE)
+                    .Min();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Implements ISSUE-033, the backlog entry submitted in #18.

## Problem

`FreeRoamingPathFinder.TryGetMaxHomeRange` and `TryGetMinSlope` aggregate over `presence.Flocks` with LINQ `Max`/`Min`. Both throw `InvalidOperationException: Sequence contains no elements` when a roaming presence has no flocks, which is a normal state rather than a fault. The surrounding `try/catch` already returns a sensible fallback, so the only visible effect is a full stack trace written to the log for every affected presence.

On a clean local P36 startup that is 8 traces, all from `TryGetMaxHomeRange`:

```
[17:11:20] ERR
Exception Found:
Type: System.InvalidOperationException
Message: Sequence contains no elements
   at Perpetuum.Zones.NpcSystem.Presences.PathFinders.FreeRoamingPathFinder.TryGetMaxHomeRange(IRoamingPresence presence) ... :line 30
```

## Change

Select the value first, then supply the fallback with `DefaultIfEmpty` before aggregating. The fallbacks are the values the `catch` blocks already return, so behaviour is unchanged in every case:

- empty flocks: `DefaultIfEmpty(10).Max()` is `10`, and `10.Clamp(10, 40)` is `10` — same as the old `return 10;`
- empty members: `DefaultIfEmpty(ZoneExtensions.MIN_SLOPE).Min()` is `MIN_SLOPE` — same as the old fallback
- non-empty: `Select(...).Max()` equals `Max(selector)`

The `try/catch` and the `Logger.Exception(e)` calls stay, so genuinely unexpected failures are still logged.

## Blast radius

Both methods are `private`. `FreeRoamingPathFinder` is constructed in one place, `src/Perpetuum.Bootstrapper/Modules/NpcsModule.cs:140`, and `.\tools\query-graph.ps1 FreeRoamingPathFinder.cs -Direction in` reports no dependents. No public contract, serialization, DB or protocol surface is touched.

## Validation

There is no automated test suite, so this was validated by running the server.

- `dotnet build PerpetuumServer2.sln -c Release -p:Platform=x64` — 0 errors, warning count unchanged
- Local P36 database, full `data\layers` set, server reached `Perpetuum Server State : [Online]`, ran for ~3 minutes, then shut down cleanly to `[Off]`

| | before | after |
|---|---|---|
| `Sequence contains no elements` | 8 | 0 |
| `FreeRoamingPathFinder` frames | 8 | 0 |
| `member spawned to zone` | present | 6406 |
| roaming presence lines | present | 10940 |

Roaming presences still spawn and move, so the fallback path is not being taken more often than before. The one unrelated exception in the log, `Maximum stored procedure, function, trigger, or view nesting level exceeded`, is present in the pre-fix log as well and is untouched by this change.
