### PR TITLE
Fix the run command and ten broken paths in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ When instructions conflict, prioritize:
 - Do not make commits unless explicitly asked.
 
 Update:
-- `.claude/knowledge/architecture.md`
+- `docs/codebase/ARCHITECTURE.md`
 
 when introducing major architectural changes.
 
@@ -53,7 +53,7 @@ when introducing major architectural changes.
 dotnet build PerpetuumServer2.sln -c Release -p:Platform=x64
 
 cd src/Perpetuum.Server
-dotnet run -- --GameRoot "E:\PerpetuumServer2\data"
+dotnet run -- "E:\PerpetuumServer2\data"
 ```
 
 CI:
@@ -74,22 +74,22 @@ The `docs/` directory is the authoritative source of truth.
 - `docs/codebase/ARCHITECTURE.md`
 
 ## Technical Concerns
-- `docs/CONCERNS.md`
+- `docs/codebase/CONCERNS.md`
 
 ## Coding Conventions
-- `docs/CONVENTIONS.md`
+- `docs/codebase/CONVENTIONS.md`
 
 ## Integrations
-- `docs/INTEGRATIONS.md`
+- `docs/codebase/INTEGRATIONS.md`
 
 ## Technology Stack
-- `docs/STACK.md`
+- `docs/codebase/STACK.md`
 
 ## Project Structure
-- `docs/STRUCTURE.md`
+- `docs/codebase/STRUCTURE.md`
 
 ## Testing Constraints
-- `docs/TESTING.md`
+- `docs/codebase/TESTING.md`
 
 ---
 
@@ -219,7 +219,7 @@ Use existing patterns:
 # Technical Debt Rules
 
 Avoid worsening known technical debt documented in:
-- `docs/CONCERNS.md`
+- `docs/codebase/CONCERNS.md`
 
 Avoid:
 - new static service locators
@@ -313,7 +313,7 @@ Avoid generating code before analysis.
 # Code Placement
 
 Before creating files:
-- verify correct subsystem placement in `docs/STRUCTURE.md`
+- verify correct subsystem placement in `docs/codebase/STRUCTURE.md`
 - follow existing namespace patterns
 - follow existing folder organization
 
@@ -328,7 +328,7 @@ Avoid parallel abstractions unless justified.
 | Purpose | File |
 |---|---|
 | Main AI instructions | `CLAUDE.md` |
-| Architecture deep-dive | `.claude/knowledge/architecture.md` |
+| Architecture deep-dive | `docs/codebase/ARCHITECTURE.md` |
 | Codebase graph & impact analysis | `.claude/knowledge/codebase-graph.md` |
 | Specialist agents | `.claude/agents/<name>.md` |
 


### PR DESCRIPTION
Implements ISSUE-034, the backlog entry submitted in #18 (scope corrected there in `afc6714`).

`CLAUDE.md` is the instruction file agents load for this repository, so a wrong path is followed rather than questioned. Ten references in it resolve to nothing, and the documented run command fails outright. All changes are confined to that one file — no build or runtime impact.

## 1. Run command (line 56)

```diff
-dotnet run -- --GameRoot "E:\PerpetuumServer2\data"
+dotnet run -- "E:\PerpetuumServer2\data"
```

`src/Perpetuum.Server/Program.cs:16` declares the game root with `app.Argument("<GAMEROOT>", ...)`, a positional argument. The documented option does not exist and the run aborts with `Unrecognized option '--GameRoot'`.

`--GameRoot` is still meaningful for `Perpetuum.ServerService2`, which reads `GameRoot` from `appsettings.json`. Only the console entry point is affected, and no line documenting the service was touched.

## 2. Documentation paths (lines 77, 80, 83, 86, 89, 92, 222, 316)

Eight references to `docs/<NAME>.md` for files that live under `docs/codebase/`: `CONCERNS.md`, `CONVENTIONS.md`, `INTEGRATIONS.md`, `STACK.md`, `STRUCTURE.md`, `TESTING.md`, plus a second `CONCERNS.md` under Technical Debt Rules and a second `STRUCTURE.md` under Code Placement. Line 74 already used the `docs/codebase/` form for `ARCHITECTURE.md`, so this makes the rest consistent with the form the file already establishes.

## 3. Knowledge file (lines 44 and 331) — decision to confirm

Both referenced `.claude/knowledge/architecture.md`, which does not exist; `.claude/knowledge/` contains only `codebase-graph.md`. Line 44 is the "update this after major architectural changes" instruction, line 331 the architecture deep-dive row of the Where to Edit table.

**Both now point at `docs/codebase/ARCHITECTURE.md`.** The alternative is to keep the instruction and create the missing file, but that would add a second architecture document alongside one the repository already treats as authoritative. This is a judgement call rather than a mechanical rename — happy to switch to the other option if you prefer it.

## Verification

Every backticked path in `CLAUDE.md` was resolved against the working tree after the edit. What remains unresolved is `Commands.cs` (line 180), `completed.md` (line 361) and `graph.json` (line 161) — all three are bare filenames used in prose, not paths, and are correct as written.
