### PR TITLE
AdminTool: Enter saves and Esc cancels in the New Item and New Robot dialogs

### DIFF
--- a/src/Perpetuum.AdminTool/Views/NewItemDialog.xaml
+++ b/src/Perpetuum.AdminTool/Views/NewItemDialog.xaml
@@ -3,7 +3,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:common="clr-namespace:Perpetuum.AdminTool.Common"
         Title="New Item" Width="960" Height="720"
-        WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+        WindowStartupLocation="CenterOwner" ShowInTaskbar="False"
+        PreviewKeyDown="OnPreviewKeyDown">
     <DockPanel>
 
         <!-- Clone picker header -->
@@ -30,9 +31,9 @@
                 <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" Foreground="DarkRed"
                            VerticalAlignment="Center" TextWrapping="Wrap"/>
                 <Button Grid.Column="1" Content="Save" Width="80" Margin="4,0"
-                        Command="{Binding SaveCommand}"/>
+                        IsDefault="True" Command="{Binding SaveCommand}"/>
                 <Button Grid.Column="2" Content="Cancel" Width="80"
-                        Command="{Binding CancelCommand}"/>
+                        IsCancel="True" Command="{Binding CancelCommand}"/>
             </Grid>
         </Border>
 

--- a/src/Perpetuum.AdminTool/Views/NewItemDialog.xaml.cs
+++ b/src/Perpetuum.AdminTool/Views/NewItemDialog.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using Perpetuum.AdminTool.NewItem;
 using Perpetuum.AdminTool.ViewModels;
 
@@ -17,6 +19,18 @@ public partial class NewItemDialog : Window
             DialogResult = success;
             Close();
         };
+    }
+
+    // Enter activates the default Save button without moving focus, so a TextBox bound with the
+    // default LostFocus trigger would still be holding an uncommitted value when Save runs. Push
+    // it to the source first. Multi-line boxes consume Enter themselves and are left alone.
+    private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter)
+            return;
+
+        if (Keyboard.FocusedElement is TextBox { AcceptsReturn: false } box)
+            box.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
     }
 
     // Tab 1 — Basic

--- a/src/Perpetuum.AdminTool/Views/NewRobotDialog.xaml
+++ b/src/Perpetuum.AdminTool/Views/NewRobotDialog.xaml
@@ -3,7 +3,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:common="clr-namespace:Perpetuum.AdminTool.Common"
         Title="New Robot" Width="1040" Height="760"
-        WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+        WindowStartupLocation="CenterOwner" ShowInTaskbar="False"
+        PreviewKeyDown="OnPreviewKeyDown">
     <DockPanel>
 
         <!-- Clone picker header -->
@@ -30,9 +31,9 @@
                 <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" Foreground="DarkRed"
                            VerticalAlignment="Center" TextWrapping="Wrap"/>
                 <Button Grid.Column="1" Content="Save" Width="80" Margin="4,0"
-                        Command="{Binding SaveCommand}"/>
+                        IsDefault="True" Command="{Binding SaveCommand}"/>
                 <Button Grid.Column="2" Content="Cancel" Width="80"
-                        Command="{Binding CancelCommand}"/>
+                        IsCancel="True" Command="{Binding CancelCommand}"/>
             </Grid>
         </Border>
 

--- a/src/Perpetuum.AdminTool/Views/NewRobotDialog.xaml.cs
+++ b/src/Perpetuum.AdminTool/Views/NewRobotDialog.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using Perpetuum.AdminTool.NewItem;
 using Perpetuum.AdminTool.ViewModels;
 
@@ -17,6 +19,18 @@ public partial class NewRobotDialog : Window
             DialogResult = success;
             Close();
         };
+    }
+
+    // Enter activates the default Save button without moving focus, so a TextBox bound with the
+    // default LostFocus trigger would still be holding an uncommitted value when Save runs. Push
+    // it to the source first. Multi-line boxes consume Enter themselves and are left alone.
+    private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter)
+            return;
+
+        if (Keyboard.FocusedElement is TextBox { AcceptsReturn: false } box)
+            box.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
     }
 
     // Tab 1 — Basic


### PR DESCRIPTION
Enter now saves and Esc now cancels in the **New Item** and **New Robot** dialogs of the AdminTool.

### Where this came from, since it explains the scope

The original idea was for the **game client**: make Enter activate the OK/Confirm button in popups that
already open with their text field focused — the Shift-drag stack-split dialog is the obvious case,
where you type the quantity and then still have to reach for the mouse.

That is not something this repository can do, and the new client is in progress and not shareable, so
the idea is parked until it is. This pull request is the same idea applied where it *is* reachable, and
it was deliberately used as a small exercise: pick a bounded change, in an area with an existing
pattern to copy, and see whether it can be made without breaking anything around it.

It stands on its own regardless of that origin. Sixteen AdminTool dialogs already pair `IsDefault` on
their confirm button with `IsCancel` on Cancel. These two were the only exceptions: Enter did nothing
and Esc did nothing, in the two largest data-entry dialogs in the tool. So this is quality of life, and
it removes an inconsistency rather than introducing a new convention.

### The part worth reviewing

`IsDefault="True"` on its own would have been a regression, which is why this is four files instead of
two attributes.

Enter activates the default button **without moving focus**. A `TextBox` bound with WPF's default
`UpdateSourceTrigger=LostFocus` is therefore still holding an uncommitted value when `SaveCommand`
runs. Roughly fifteen fields across these two dialogs are bound that way — `Mass`, `Volume`, `Health`
and `Quantity` among them; only `DefinitionName`, `CategoryFlags`, `AttributeFlags` and
`DescriptionToken` use `PropertyChanged`.

Measured rather than argued. With the hook removed, typing `555` into **Mass** and pressing Enter
generated:

```sql
INSERT INTO entitydefaults (..., mass, ...) VALUES (..., 0, ...)
```

With the hook in place, the typed value reaches the generated SQL. So without the `PreviewKeyDown`
handler, adding the shortcut would have silently written blank fields — worse than having no shortcut.

The handler pushes the focused single-line `TextBox` to its source before the key propagates.
Multi-line boxes are skipped explicitly: they consume Enter themselves, so the Note field still inserts
a newline.

`IsCancel` was the other thing checked rather than assumed. `CancelCommand` already closes the dialog
through `CloseRequested`, so `IsCancel` adds a second path. That is not new: the existing sixteen
dialogs all pair `IsCancel="True"` with a `Click` handler that sets `DialogResult = false`, so the same
double set is already in production and works.

### Validation

No test tier covers the AdminTool, so this was verified by hand against a local database with the
session in SQL-script mode, which writes a file instead of touching the database:

- Enter saves, and the value typed last reaches the generated SQL
- Enter with the handler removed produces `mass = 0` — the regression observed failing, per the
  repository's own rule
- Esc closes without saving
- Enter inserts a newline in the multi-line **Note** box rather than saving
- Enter still commits a `DataGrid` cell and moves down rather than saving the item — this one mattered,
  since the handler runs on the window's `PreviewKeyDown`, before the grid sees the key

Solution builds clean; the unit and integration tiers and the smoke script were run and are unaffected,
as none of them reach the AdminTool.

### One question

If you would rather the two dialogs matched the other sixteen exactly — `Click` handlers instead of
`Command` bindings — say so and I will convert them. I left the MVVM shape alone because changing it
would be a larger diff than the behaviour being added.
